### PR TITLE
Update release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,8 +34,18 @@ version-resolver:
     labels:
       - 'minor'
       - 'new-feature'
+      - 'feature'
+      - 'enhancement'
+      - 'chore'
+      - 'documentation'
+      - 'test'
+      - 'hosting'
+      - 'ci'
   patch:
     labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
       - 'patch'
   default: patch
 template: |


### PR DESCRIPTION
A mon sens, tous les labels qu'on ventile en section dans les releases notes devraient avoir un impact sur la version.
Comme patch devrait être réservé aux bugfix: [PATCH version when you make backwards compatible bug fixes](https://semver.org/#:~:text=PATCH%20version%20when%20you%20make%20backwards%20compatible%20bug%20fixes)

J'ai placé tous les autres labels en [minor](https://semver.org/#:~:text=MINOR%20version%20when%20you%20add%20functionality%20in%20a%20backwards%20compatible%20manner).