### PR TITLE
Categorize dependabot PR

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,6 +23,7 @@ categories:
     labels:
       - 'chore'
       - 'documentation'
+      - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
@@ -38,6 +39,7 @@ version-resolver:
       - 'enhancement'
       - 'chore'
       - 'documentation'
+      - 'dependencies'
       - 'test'
       - 'hosting'
       - 'ci'


### PR DESCRIPTION
`dependabot` utilise ce label pour ses PRs.
Ca permettra de les lister dans la section `Maintenance`.